### PR TITLE
Use new base template

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -5,9 +5,9 @@
   "description" : "IHE FHIR Template",
   "author" : "http://ihe.net",
   "canonical" : "http://fhir.org/templates/ihe.fhir.template",
-  "base" : "fhir.base.template",
+  "base" : "fhir2.base.template",
   "dependencies" : {
-    "fhir.base.template" : "current"
+    "fhir2.base.template" : "0.1.0"
   },
-  "version" : "1.0.0"
+  "version" : "2.0.0"
 }


### PR DESCRIPTION
Closes #27 
Closes #28

## 📑 Description
Use the new FHIR base template as dependency. No impact on user expected unless they use custom includes - which will be visible as from the moment they build.

- [ ] Not Completed
- [x] Completed

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [X] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [ ] All the tests have passed
- [ ] I have selected a committee co-chair to review the PR

## ℹ Additional Information
